### PR TITLE
update contract licenses

### DIFF
--- a/packages/hardhat/contracts/Authorizable.sol
+++ b/packages/hardhat/contracts/Authorizable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Faucet.sol
+++ b/packages/hardhat/contracts/Faucet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Fees/FeeCollector.sol
+++ b/packages/hardhat/contracts/Fees/FeeCollector.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Fees/Fees.sol
+++ b/packages/hardhat/contracts/Fees/Fees.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Fees/IFeeCollector.sol
+++ b/packages/hardhat/contracts/Fees/IFeeCollector.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Fees/IFees.sol
+++ b/packages/hardhat/contracts/Fees/IFees.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Governance/Governable.sol
+++ b/packages/hardhat/contracts/Governance/Governable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Governance/Governor.sol
+++ b/packages/hardhat/contracts/Governance/Governor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Governance/IGovernable.sol
+++ b/packages/hardhat/contracts/Governance/IGovernable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Governance/IGovernor.sol
+++ b/packages/hardhat/contracts/Governance/IGovernor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/IAuthorizable.sol
+++ b/packages/hardhat/contracts/IAuthorizable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/IDCounter.sol
+++ b/packages/hardhat/contracts/IDCounter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/IIDCounter.sol
+++ b/packages/hardhat/contracts/IIDCounter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/IPausable.sol
+++ b/packages/hardhat/contracts/IPausable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Launches/ILaunchManagerV1.sol
+++ b/packages/hardhat/contracts/Launches/ILaunchManagerV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Launches/LaunchManagerV1.sol
+++ b/packages/hardhat/contracts/Launches/LaunchManagerV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Launches/LaunchV1.sol
+++ b/packages/hardhat/contracts/Launches/LaunchV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Pausable.sol
+++ b/packages/hardhat/contracts/Pausable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/IStakingFactoryV1.sol
+++ b/packages/hardhat/contracts/Staking/IStakingFactoryV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/IStakingManagerV1.sol
+++ b/packages/hardhat/contracts/Staking/IStakingManagerV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/IStakingTokenV1.sol
+++ b/packages/hardhat/contracts/Staking/IStakingTokenV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/IStakingV1.sol
+++ b/packages/hardhat/contracts/Staking/IStakingV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/SplitStakingV1.sol
+++ b/packages/hardhat/contracts/Staking/SplitStakingV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/StakingFactoryV1.sol
+++ b/packages/hardhat/contracts/Staking/StakingFactoryV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/StakingManagerV1.sol
+++ b/packages/hardhat/contracts/Staking/StakingManagerV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/StakingTokenV1.sol
+++ b/packages/hardhat/contracts/Staking/StakingTokenV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        

--- a/packages/hardhat/contracts/Staking/StakingV1.sol
+++ b/packages/hardhat/contracts/Staking/StakingV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0+
 
 /**
   /$$$$$$            /$$           /$$      /$$                                        


### PR DESCRIPTION
Note: contracts that have already been deployed to mainnet as `UNLICENSED` are not updated here. This is because they cannot be redeployed.